### PR TITLE
fix Darwin security build bug

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -31,12 +31,14 @@
             default = crane.stable.buildPackage {
               src = ./.;
               cargoBuildCommand = "cargo build --release";
+              buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Security ]);
             };
           };
           devShells = {
             default = pkgs.mkShell {
               buildInputs = [ self'.packages.rust-stable ]
                 ++ (with pkgs; [ bacon rnix-lsp hyperfine cargo-flamegraph ]);
+                ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Security ]));
             };
           };
         };


### PR DESCRIPTION
When using Tokyo in a rust project, sometimes a problem occurs when building with cargo on Darwin platforms. This PR fixes that. 