### PR TITLE
Remove ; in rust template

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -37,7 +37,7 @@
           devShells = {
             default = pkgs.mkShell {
               buildInputs = [ self'.packages.rust-stable ]
-                ++ (with pkgs; [ bacon rnix-lsp hyperfine cargo-flamegraph ]);
+                ++ (with pkgs; [ bacon rnix-lsp hyperfine cargo-flamegraph ])
                 ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Security ]));
             };
           };


### PR DESCRIPTION
The rust flake template didn't work, because there was an unexpected semicolon. This pr fixes that.